### PR TITLE
Send response to 550 and 552

### DIFF
--- a/test/sendMessage.js
+++ b/test/sendMessage.js
@@ -56,5 +56,67 @@ describe('index.js', function() {
             done();
           });
       });
+    
+    it('should invoke the AWS SES SDK to send the bounce message',
+      function(done) {
+        var data = {
+          config: {
+            notifyEmail: "MAILER-DAEMON@example.com",
+            notify550: true,
+            notify552: true,
+          },
+          smtpErr: "552",
+          recipients: [
+            "jim@example.com"
+          ],
+          originalRecipients: [
+            "info@example.com"
+          ],
+          emailData: "message data",
+          context: {},
+          log: console.log,
+          ses: {
+            sendEmail: function(options, callback) {
+              callback(null, {status: "ok"});
+            }
+          }
+        };
+        index.sendMessage(data)
+          .then(function() {
+            assert.ok(true, "sendMessage returned successfully");
+            done();
+          });
+      });
+    
+    it('should result in failure if the AWS SES SDK cannot send the bounce message',
+      function(done) {
+        var data = {
+          config: {
+            notifyEmail: "MAILER-DAEMON@example.com",
+            notify550: true,
+            notify552: true,
+          },
+          smtpErr: "550",
+          recipients: [
+            "jim@example.com"
+          ],
+          originalRecipients: [
+            "info@example.com"
+          ],
+          emailData: "message data",
+          context: {},
+          log: console.log,
+          ses: {
+            sendEmail: function(options, callback) {
+              callback(true);
+            }
+          }
+        };
+        index.sendMessage(data)
+          .catch(function(err) {
+            assert.ok(err, "sendMessage bounce msg aborted operation");
+            done();
+          });
+      });
   });
 });

--- a/test/transformRecipients.js
+++ b/test/transformRecipients.js
@@ -218,5 +218,29 @@ describe('index.js', function() {
             done();
           });
       });
+    
+    it('should give error code 550',
+      function(done) {
+        var data = {
+          recipients: ["norecipient@foo.com"],
+          config: {
+            forwardMapping: {
+              "info@foo.com": [
+                "jim@example.com"
+              ]
+            },
+            notifyEmail: "MAILER-DAEMON@example.com",
+            notify550: true
+          },
+          log: console.log
+        };
+        index.transformRecipients(data)
+          .then(function(data) {
+            assert.equal(data.config.notify550,
+              "550",
+              "smpt error code enabled");
+            done();
+          });
+      });
   });
 });

--- a/test/transformRecipients.js
+++ b/test/transformRecipients.js
@@ -236,9 +236,9 @@ describe('index.js', function() {
         };
         index.transformRecipients(data)
           .then(function(data) {
-            assert.equal(data.config.notify550,
+            assert.equal(data.smtpErr,
               "550",
-              "smpt error code enabled");
+              "smpt error code 550 enabled");
             done();
           });
       });


### PR DESCRIPTION
PR with own PR from https://github.com/arithmetric/aws-lambda-ses-forwarder/pull/127 .

This PR consist of two main elements - auto response on:
- SMTP 550 - no recipient found
- SMTP 552 - mail size exceeds 10 MB

## 550 - no recipient found
When a person is sending an email, and global catch (`@example.com`) is not enabled, the email will just disappear - neither the sender nor the email-admin will be notified. If the new "notify"-config is enabled, the sender will be informed, that the recipient does not exists.

### Config
```
notifyEmail: "MAILER-DAEMON@example.com",
notify550: true,
```

### Response
```
An error occurred while trying to deliver the mail to the following recipients: test@example.com

Your email was rejected. The email address was not found. Please check the receiving email address.

SMTP Reply Code = 550, SMTP Status Code = 5.1.1
```

## 552 - mail size exceeds 10 MB
Another problem is when the mail size exceeds AWS's limit on 10MB. This will also fail silently (#97, #124) - not notifying either the sender or the email-admin. If the new "notify"-config is enabled, the sender will be informed, that the recipient does not exists.

### Config
```
notifyEmail: "MAILER-DAEMON@example.com",
notify552: true,
```

### Response
```
An error occurred while trying to deliver the mail to the following recipients: test@example.com

Your email was rejected. Please ensure that the size of your mail is less than 10 MB.

SMTP Reply Code = 552, SMTP Status Code = 5.3.4
```